### PR TITLE
Use a three-state checkbox to preserve conformance default value

### DIFF
--- a/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIConformance.java
+++ b/src/community/ogcapi/ogcapi-core/src/main/java/org/geoserver/ogcapi/APIConformance.java
@@ -16,6 +16,7 @@ import java.util.Objects;
  * <p>By comparison OGC Open Web Services can be extended using application profiles with
  * additional, optional, functionality.
  */
+@SuppressWarnings("serial")
 public class APIConformance implements Serializable {
 
     /** There are three levels of standard. */

--- a/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureConformance.java
+++ b/src/community/ogcapi/ogcapi-features/src/main/java/org/geoserver/ogcapi/v1/features/FeatureConformance.java
@@ -15,6 +15,7 @@ import org.geoserver.ogcapi.ConformanceInfo;
 import org.geoserver.wfs.WFSInfo;
 
 /** FeatureService configuration. */
+@SuppressWarnings("serial")
 public class FeatureConformance extends ConformanceInfo<WFSInfo> {
     public static String METADATA_KEY = "ogcapiFeatures";
 

--- a/src/community/ogcapi/web-features/src/main/java/org/geoserver/ogcapi/web/FeatureServiceAdminPanel.java
+++ b/src/community/ogcapi/web-features/src/main/java/org/geoserver/ogcapi/web/FeatureServiceAdminPanel.java
@@ -6,7 +6,6 @@ package org.geoserver.ogcapi.web;
 
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.form.AjaxCheckBox;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.model.IModel;
@@ -18,13 +17,11 @@ import org.geoserver.ogcapi.v1.features.FeatureConformance;
 import org.geoserver.web.services.AdminPagePanel;
 import org.geoserver.wfs.WFSInfo;
 
+@SuppressWarnings("serial")
 public class FeatureServiceAdminPanel extends AdminPagePanel {
 
     public FeatureServiceAdminPanel(String id, final IModel<?> info) {
         super(id, info);
-
-        WFSInfo wfsInfo = (WFSInfo) info.getObject();
-
         featureServiceSettings(info);
         cql2Settings(info);
         ecqlSettings(info);
@@ -114,7 +111,7 @@ public class FeatureServiceAdminPanel extends AdminPagePanel {
      * @param key Wicket id of checkbox, also used to obtained internationalization text
      * @param conformance Conformance class to be represented by the checkbox
      * @param booleanModel Model, often backed by WFSInfo, to store checkbox value.
-     * @param enabled Lamnda used to determine in conformance is enabled
+     * @param enabled Lambda used to determine in conformance is enanbled (i.e. implemented and configurable)
      * @return checkbox component to be used if further customization is required
      */
     protected CheckBox addConformance(
@@ -136,13 +133,17 @@ public class FeatureServiceAdminPanel extends AdminPagePanel {
 
         Label level = new Label(key + "Level", level(conformance.getLevel()));
         level.add(new AttributeModifier("title", recommendation(conformance.getLevel())));
-        final CheckBox checkBox =
-                new AjaxCheckBox(key, booleanModel) {
+        final ThreeStateAjaxCheckBox checkBox =
+                new ThreeStateAjaxCheckBox(key, booleanModel) {
                     @Override
                     protected void onUpdate(AjaxRequestTarget target) {
+
                         Label uriLabel = (Label) FeatureServiceAdminPanel.this.get(key + "Label");
-                        boolean checked = getModelObject();
-                        uriLabel.setVisible(checked);
+
+                        Boolean modelValue = getModelObject();
+
+                        boolean visible = modelValue == null || modelValue.booleanValue();
+                        uriLabel.setVisible(visible);
                         uriLabel.setDefaultModelObject(conformance.getId());
                         target.add(uriLabel);
                     }

--- a/src/community/ogcapi/web-features/src/main/java/org/geoserver/ogcapi/web/ThreeStateAjaxCheckBox.java
+++ b/src/community/ogcapi/web-features/src/main/java/org/geoserver/ogcapi/web/ThreeStateAjaxCheckBox.java
@@ -1,0 +1,103 @@
+/* (c) 2024 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.geoserver.ogcapi.web;
+
+import org.apache.wicket.ajax.markup.html.form.AjaxCheckBox;
+import org.apache.wicket.model.IModel;
+import org.geoserver.ogcapi.ConformanceInfo;
+import org.springframework.lang.Nullable;
+
+/**
+ * Three-state {@link AjaxCheckBox} preserving the {@code null} initial model
+ * value.
+ * <p>
+ * <ul>
+ * <li>If the initial state is undefined (null), checking and unchecking
+ * resolves to undefined.
+ * <li>If the initial state is false, checking and unchecking resolves back to
+ * false.
+ * </ul>
+ * <p>
+ * This prevents the "undefined" states to be persisted as {@code false} when
+ * serializing the {@link ConformanceInfo}.
+ * <p>
+ * <strong>Beware</strong> {@link #getModel()} can hence return {@code null}.
+ */
+@SuppressWarnings("serial")
+abstract class ThreeStateAjaxCheckBox extends AjaxCheckBox {
+
+    public enum State {
+        TRUE(true), FALSE(false), UNDEFINED(null);
+
+        @Nullable
+        private Boolean value;
+
+        private State(Boolean nullableState) {
+            this.value = nullableState;
+        }
+
+        @Nullable
+        public Boolean value() {
+            return value;
+        }
+
+        public static State valueOf(Boolean value) {
+            return null == value ? UNDEFINED : value.booleanValue() ? TRUE : FALSE;
+        }
+    }
+
+    private State state;
+
+    private final State initialState;
+
+    public ThreeStateAjaxCheckBox(String id, IModel<Boolean> model) {
+        super(id, model);
+        this.state = State.valueOf(model.getObject());
+        this.initialState = state;
+        super.internalOnModelChanged();
+    }
+
+    /**
+     * @return {@code null} when the initial state is {@code null} and the final
+     *         state is "unchecked", {@code true} or {@code false} otherwise
+     *         according to the model value.
+     */
+    @Override
+    @Nullable
+    public Boolean getModelObject() {
+        return super.getModelObject();
+    }
+
+    /**
+     * Prevents the null (undefined) state from being replaced by false during form
+     * submission by directly handling the model’s value
+     */
+    @Override
+    public void updateModel() {
+        Boolean convertedInput = super.getConvertedInput();
+
+        if (State.UNDEFINED == initialState && Boolean.FALSE.equals(convertedInput)) {
+            state = State.UNDEFINED;
+        } else {
+            state = State.valueOf(convertedInput);
+        }
+
+        setModelObject(state.value());
+    }
+
+    /**
+     * Ensure the “checked” attribute is removed when the state is undefined
+     */
+    @Override
+    protected void onComponentTag(org.apache.wicket.markup.ComponentTag tag) {
+        super.onComponentTag(tag);
+
+        if (state == State.TRUE) {
+            tag.put("checked", "checked");
+        } else {// holds on for both FALSE and UNDEFINED
+            tag.remove("checked");
+        }
+    }
+}


### PR DESCRIPTION
The checkboxes in FeatureServiceAdminPanel would otherwise update the model value to false when it was originally null.

This way the XStream persister will get the unchanged values as null instead of false.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geoserver/geoserver/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geoserver.org/latest/en/developer/policies/committing.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geoserver.org/latest/en/developer/qa-guide/index.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geoserver/geoserver/tree/main/doc/en/user/source) has been updated (if change is visible to end users).
- [ ] The [REST API docs](https://github.com/geoserver/geoserver/tree/main/doc/en/api/1.0.0) have been updated (when changing configuration objects or the REST controllers).
- [ ] There is an issue in the [GeoServer Jira](https://osgeo-org.atlassian.net/browse/GEOS/summary) (except for changes that do not affect administrators or end users in any way).
- [ ] Commit message(s) must be in the form ``[GEOS-XYZWV] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective (if there are multiple commits, each has a separate JIRA ticket describing its goal).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
